### PR TITLE
rm rustpython

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ chrono = { version = "0.4.31", features = ["serde"] }
 clap = { version = "4.4.7", features = ["derive"] }
 regex = "1.10.2"
 reqwest = { version = "0.11.22", features = ["json"] }
-rustpython = "0.3.0"
+#rustpython = "0.3.0"
 serde = { version = "1.0.190", features = ["derive"] }
 serde_json = "1.0.107"
 structopt = "0.3.26"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use clap::{parser, Parser, ValueEnum};
-use rustpython::vm::stdlib::builtins::print;
 use std::borrow::BorrowMut;
 use std::path::PathBuf;
 


### PR DESCRIPTION
diffを取得した後に使うが、buildに失敗するケースに遭遇したので、それまでコメントアウト